### PR TITLE
Update alarms limits

### DIFF
--- a/doc/release.notes
+++ b/doc/release.notes
@@ -4,6 +4,14 @@
  *
  *                  EOH
 
+ - Updating alarm limits on Lac thresholds for 4 channels:
+     Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_13_3_3:  upper warning limit changed from  2.8 to 2.9
+     Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_3_7_6:   upper warning limit changed from  2.75 to 2.85
+     Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_13_3_2:  upper warning limit changed from  2.75 to 2.85
+     Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_3_1_1:   upper warning limit changed from  2.75 to 2.85
+ - Updating warning limit on CalXAdcPedRMS_LEX8_TH1:
+       upper warning limit changed from      5.85 to 5.95 
+
  AlarmsCfg-07-01-00 27-Jan-2024 monzani Tagging from new repository on github
  -AlarmsCfg repository was moved to https://github.com/fermi-lat/AlarmsCfg
       No changes to actual alarms. SConscript was removed because unneeded with git

--- a/doc/release.notes
+++ b/doc/release.notes
@@ -10,7 +10,8 @@
      Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_13_3_2:  upper warning limit changed from  2.75 to 2.85
      Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_3_1_1:   upper warning limit changed from  2.75 to 2.85
  - Updating warning limit on CalXAdcPedRMS_LEX8_TH1:
-       upper warning limit changed from      5.85 to 5.95 
+       upper warning limit changed from      5.85 to 5.95      
+  Relevant threads https://www-glast.stanford.edu/protected/mail/datamon/4038.html
 
  AlarmsCfg-07-01-00 27-Jan-2024 monzani Tagging from new repository on github
  -AlarmsCfg repository was moved to https://github.com/fermi-lat/AlarmsCfg

--- a/xml/calpeds_eor_alarms.xml
+++ b/xml/calpeds_eor_alarms.xml
@@ -161,10 +161,10 @@
         <condition name="min_entries" value="750000"/>
       </alarm>
       <alarm function="y_average" enabled="True">
-	<warning_limits min="5.25" max="5.85"/>
+	<warning_limits min="5.25" max="5.95"/>
 	<error_limits   min="4.25" max="7.25"/>
         <condition name="min_entries" value="750000"/>
-        <parameter name="exclude" value="[1983+1, 2414+1, 1160+1, 1685+1, 824+1, 848+1, 1250+1,1692+1]"/> 
+        <parameter name="exclude" value="[1983+1, 2414+1, 1160+1, 1685+1, 824+1, 848+1, 1250+1,1692+1]"/>
       </alarm>
     </alarmSet>
 

--- a/xml/recon_eor_alarms.xml
+++ b/xml/recon_eor_alarms.xml
@@ -39,7 +39,7 @@
 
 
     
-    <alarmSet name="Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_*_*_*" exclude="[846,1311,1172,1051,1333,1314,863,1332,140, 13510, 243]" enabled="True">
+    <alarmSet name="Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_*_*_*" exclude="[846,1311,1172,1051,1333,1314,863,1332,140, 13510, 243, 311]" enabled="True">
       <alarm function="leftmost_edge" enabled="True">
 	<condition name="min_entries" value="750"/>
 	<parameter name="window_half_width" value="12"/>
@@ -114,14 +114,14 @@
     </alarmSet>
 
     
-    <!-- 2 October 2020  relaxing warning limits on xtal 13 3 3 --> 
+    <!-- 2 October 2020  relaxing warning limits on xtal 13 3 3, updated 19 April 2024 --> 
     <alarmSet name="Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_13_3_3" enabled="True">
       <alarm function="leftmost_edge" enabled="True">
 	<condition name="min_entries" value="750"/>
 	<parameter name="window_half_width" value="12"/>
 	<parameter name="threshold" value="15"/>
 	<parameter name="start_x" value="0.5"/>
-	<warning_limits min="1.25" max="2.8"/>
+	<warning_limits min="1.25" max="2.9"/>
 	<error_limits min="1.0" max="3.0"/>
       </alarm>
     </alarmSet>
@@ -172,7 +172,23 @@
       </alarm>
     </alarmSet>
 
-    <alarmSet name="Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_*_*_*" exclude="[13410, 428,1314,1311,853,350,112,11111,1076, 13510,4510]" enabled="True">
+<!-- 23 April 2024  relaxing warning limits on xtal  3 1 1   -->  
+    <alarmSet name="Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_3_1_1" enabled="True">
+      <alarm function="leftmost_edge" enabled="True">
+	<condition name="min_entries" value="750"/>
+	<parameter name="window_half_width" value="12"/>
+	<parameter name="threshold" value="15"/>
+	<parameter name="start_x" value="0.5"/>
+	<warning_limits min="1.25" max="2.85"/>
+	<error_limits min="1.0" max="3.0"/>
+      </alarm>
+    </alarmSet>
+
+
+
+    
+
+    <alarmSet name="Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_*_*_*" exclude="[13410, 428,1314,1311,853,350,112,11111,1076, 13510,4510,376,1332]" enabled="True">
       <alarm function="leftmost_edge" enabled="True">
 	<condition name="min_entries" value="750"/>
 	<parameter name="window_half_width" value="12"/>
@@ -291,6 +307,29 @@
       </alarm>
  </alarmSet>
 
+ <!-- 23 April  2024  relaxing warning limits on xtal 3 7 6 -->  
+  <alarmSet name="Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_3_7_6" enabled="True">
+      <alarm function="leftmost_edge" enabled="True">
+	<condition name="min_entries" value="750"/>
+	<parameter name="window_half_width" value="12"/>
+	<parameter name="threshold" value="15"/>
+	<parameter name="start_x" value="0.5"/>
+	<warning_limits min="1.25" max="2.85"/>
+	<error_limits min="1.0" max="3.0"/>
+      </alarm>
+ </alarmSet>
+
+  <!-- 23 April  2024  relaxing warning limits on xtal 13 3 2 -->  
+  <alarmSet name="Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_13_3_2" enabled="True">
+      <alarm function="leftmost_edge" enabled="True">
+	<condition name="min_entries" value="750"/>
+	<parameter name="window_half_width" value="12"/>
+	<parameter name="threshold" value="15"/>
+	<parameter name="start_x" value="0.5"/>
+	<warning_limits min="1.25" max="2.85"/>
+	<error_limits min="1.0" max="3.0"/>
+      </alarm>
+ </alarmSet>
 
  
 


### PR DESCRIPTION
- Updating alarm limits on Lac thresholds for 4 channels:
     Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_13_3_3:  upper warning limit changed from  2.8 to 2.9
     Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_3_7_6:   upper warning limit changed from  2.75 to 2.85
     Lac_Thresholds_FaceNeg_TH1_TowerCalLayerCalColumn_13_3_2:  upper warning limit changed from  2.75 to 2.85
     Lac_Thresholds_FacePos_TH1_TowerCalLayerCalColumn_3_1_1:   upper warning limit changed from  2.75 to 2.85
 - Updating warning limit on CalXAdcPedRMS_LEX8_TH1:
       upper warning limit changed from      5.85 to 5.95      
  Relevant threads https://www-glast.stanford.edu/protected/mail/datamon/4038.html
